### PR TITLE
Removing Default title text

### DIFF
--- a/library/src/main/res/layout/alert_dialog.xml
+++ b/library/src/main/res/layout/alert_dialog.xml
@@ -124,8 +124,7 @@
         android:textSize="19sp"
         android:textColor="#575757"
         android:layout_marginTop="10dp"
-        android:singleLine="true"
-        android:text="@string/dialog_default_title" />
+        android:singleLine="true"/>
 
     <TextView
         android:id="@+id/content_text"


### PR DESCRIPTION
For some users who wants to create a dialog with no title it is super annoying to set an empty string. Also, for those who wants to set up a title they will have to call the method anyway. This is String is only creating extra work for users.

https://github.com/pedant/sweet-alert-dialog/pull/112